### PR TITLE
Fix target.size calculation for remote_transform_rect

### DIFF
--- a/addons/tnowe_extra_controls/elements/remote_transform_rect.gd
+++ b/addons/tnowe_extra_controls/elements/remote_transform_rect.gd
@@ -37,7 +37,7 @@ func _draw():
   if update_size:
     var new_size := size * target_scale * xform.get_scale()
     target.custom_minimum_size = new_size
-    target.size = size * new_size
+    target.size = new_size
 
   if update_position:
     if use_global_coordinates: target.global_position = xform.origin


### PR DESCRIPTION
`new_size` already includes `size`.